### PR TITLE
Card photo scaling fixed(sort of) in artpieces/index

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -5,3 +5,4 @@
 @import "navbar";
 @import "container";
 @import "gallery";
+@import "cards";

--- a/app/assets/stylesheets/components/cards.scss
+++ b/app/assets/stylesheets/components/cards.scss
@@ -1,0 +1,5 @@
+.object-fit-cover {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}

--- a/app/views/artpieces/index.html.erb
+++ b/app/views/artpieces/index.html.erb
@@ -4,7 +4,7 @@
       <% @artpieces.each do |artpiece| %>
         <div class="col-lg-4 col-sm-12 col-md-6 d-flex align-items-stretch">
           <div class="card mb-2 border-0">
-            <div><%= cl_image_tag artpiece.photos.first.key, crop: "fill", class: "card-img rounded-3" %></div>
+            <div class="h-75"><%= cl_image_tag artpiece.photos.first.key, :crop=>"fill", class: "object-fit-cover rounded-3" %></div>
             <div class="card-body p-0">
                 <p class="card-title m-0 lh-sm"><%= link_to artpiece.title, artpiece_path(artpiece), class:"text-decoration-none stretched-link text-dark fs-4 fw-normal" %></p>
                 <div class="card-text d-flex align-content-start">


### PR DESCRIPTION
seem to have fixed the scaling issue locally - created a CSS file for the cards to do so. May not be sustainable long term though, as it doesn't seem to crop the images nicely. Possible solution may be in the cloudinary docs, but I can't figure it out atm.